### PR TITLE
Fix unassigned local variable for Visual Studio

### DIFF
--- a/Assets/AWSUnitySDK/AWSCore/Amazon.CognitoIdentity/CognitoAWSCredentials.cs
+++ b/Assets/AWSUnitySDK/AWSCore/Amazon.CognitoIdentity/CognitoAWSCredentials.cs
@@ -266,7 +266,7 @@ namespace Amazon.CognitoIdentity
 		{
 			AmazonServiceResult voidResult = new AmazonServiceResult(null, null);
 
-			AmazonServiceCallback refreshCallback;
+			AmazonServiceCallback refreshCallback = null;
 			refreshCallback = delegate(AmazonServiceResult refreshResult)
 			{
 				if (refreshResult.Exception != null)


### PR DESCRIPTION
Visual Studio Professional 2013 complains about refreshCallback being unassigned in the closure which prevents being able to run the debugger with Unity.