### PR TITLE
*Don't* swallow errors from the callback.  Let it fail, in another th…

### DIFF
--- a/Assets/AWSSDK/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
+++ b/Assets/AWSSDK/src/Core/Amazon.Util/Internal/InternalSDKUtils.cs
@@ -207,18 +207,7 @@ namespace Amazon.Util.Internal
 
         public static void SafeExecute(Action action)
         {
-            try
-            {
-                action();
-            }
-            catch (Exception exception)
-            {
-                // Catch any unhandled exceptions from the user callback 
-                // and log it. 
-                Logger.Error(exception,
-                    "An unhandled exception was thrown from the callback method {0}.",
-                    action.Method.Name);
-            }
+			UnityInitializer.StartDetached(action);
         }
 #endif
 

--- a/Assets/AWSSDK/src/Core/_unity/UnityInitializer.cs
+++ b/Assets/AWSSDK/src/Core/_unity/UnityInitializer.cs
@@ -119,6 +119,21 @@ namespace Amazon
             return Thread.CurrentThread.Equals(_mainThread);
         }
 
+		public static void StartDetached(Action lambda)
+		{
+			if(null != _instance)
+			{
+				_instance.StartCoroutine( startDetached(lambda) );
+			}
+		}
+
+		private static IEnumerator startDetached(Action lambda)
+		{
+			yield return null;
+
+			lambda.Invoke();
+		}
+
 #if UNITY_EDITOR
         public static bool IsEditorPlaying
         {


### PR DESCRIPTION
…read / Coroutine, but _don't_ swallow it.  It causes all sorts of issues in real-life scenarios.

This is especially relevant for how we all work with the Amazon SDK, with anonymous lambdas, so the only sort of debugging information you get after an exception has been thrown is something like,

```
 An unhandled exception was thrown from the callback method, <>m__0
```

Swallowing errors, and displaying incomplete largely unhelpful reports of those errors is really, really, really bad practise _ESPECIALLY_ when we're talking about swallowing errors of CALLBACK methods.  Sure, you don't want to break your internal flow, that's fine.  But then detach from it, through another thread, or coroutine, but _DON'T_ swallow the errors.
