### PR TITLE
Checks result of GetSignedPolicy during PostObjectAsync call

### DIFF
--- a/Assets/AWSSDK/src/Core/Amazon.Runtime/AWSCredentials.cs
+++ b/Assets/AWSSDK/src/Core/Amazon.Runtime/AWSCredentials.cs
@@ -694,7 +694,7 @@ namespace Amazon.Runtime
         #region Override methods
 
         /// <summary>
-        /// Returns an instance of ImmutableCredentials for this instance
+		/// Returns an instance of ImmutableCredentials for this instance, or null if the request failed
         /// </summary>
         /// <returns></returns>
         public override ImmutableCredentials GetCredentials()
@@ -705,10 +705,15 @@ namespace Amazon.Runtime
                 if (ShouldUpdate)
                 {
                     _currentState = GenerateNewCredentials();
-                    UpdateToGeneratedCredentials(_currentState);
+
+					if (_currentState != null)
+						UpdateToGeneratedCredentials(_currentState);
                 }
 
-                return _currentState.Credentials.Copy();
+				if (_currentState != null)
+					return _currentState.Credentials.Copy();
+				else
+					return null;
             }
         }
 

--- a/Assets/AWSSDK/src/Services/S3/Custom/Util/_bcl/S3PostUploadSignedPolicy.cs
+++ b/Assets/AWSSDK/src/Services/S3/Custom/Util/_bcl/S3PostUploadSignedPolicy.cs
@@ -44,10 +44,19 @@ namespace Amazon.S3.Util
         /// </summary>
         /// <param name="policy">JSON string representing the policy to sign</param>
         /// <param name="credentials">Credentials to sign the policy with</param>
-        /// <returns>A signed policy object for use with an S3PostUploadRequest.</returns>
+		/// <returns>A signed policy object for use with an S3PostUploadRequest. If the request failed, null is returned</returns>
         public static S3PostUploadSignedPolicy GetSignedPolicy(string policy, AWSCredentials credentials)
         {
-            ImmutableCredentials iCreds = credentials.GetCredentials();
+			ImmutableCredentials iCreds = null;
+
+			try
+			{
+				iCreds = credentials.GetCredentials();
+			}
+			catch
+			{
+				return null;
+			}
 
             var policyBytes = iCreds.UseToken
                 ? addTokenToPolicy(policy, iCreds.Token)


### PR DESCRIPTION
Fixes #108 by checking the result of the GetSignedPolicy request. Improvements can be made to pass the WebResponse object that resulted in the failure back through the chain. Better than nothing though!
