### PR TITLE
Fix for issue #99

### DIFF
--- a/Assets/AWSSDK/src/Services/MobileAnalytics/Custom/Event/_unity/CustomEvent.cs
+++ b/Assets/AWSSDK/src/Services/MobileAnalytics/Custom/Event/_unity/CustomEvent.cs
@@ -345,6 +345,17 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager
         #endregion
         
         #region gloablattribute
+
+        /// <summary>
+        /// Returns a copy of the global attributes dictionary
+        /// </summary>
+        /// <returns>A copy of the global attributes dictionary</returns>
+        public static Dictionary<string, string> GetGlobalAttributes() {
+            lock (_globalLock) {
+                return new Dictionary<string, string>(_globalAttributes);
+            }
+        }
+
         /// <summary>
         /// Adds the global attribute, which is valid for all events.
         /// </summary>
@@ -532,6 +543,17 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager
         #endregion
         
         #region globalmetric
+
+        /// <summary>
+        /// Get a copy of the global metrics dictionary
+        /// </summary>
+        /// <returns>A copy of the global metrics dictionary</returns>
+        public static Dictionary<string, double> GetGlobalMetrics() {
+            lock (_globalLock) {
+                return new Dictionary<string, double>(_globalMetrics);
+            }
+        }
+
         /// <summary>
         /// Adds the global metric, which is valid for all events.
         /// </summary>

--- a/Assets/AWSSDK/src/Services/MobileAnalytics/Custom/Session/_unity/Session.unity.cs
+++ b/Assets/AWSSDK/src/Services/MobileAnalytics/Custom/Session/_unity/Session.unity.cs
@@ -25,6 +25,7 @@ using Amazon.Runtime.Internal;
 using Amazon.Runtime.Internal.Util;
 using System.Threading;
 using Amazon.Util.Internal;
+using System.Collections.Generic;
 
 namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
 {
@@ -68,6 +69,8 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
             public DateTime _preStartTime;
             public string _sessionId;
             public long _duration;
+            public Dictionary<string, string> _globalAttributes;
+            public Dictionary<string, double> _globalMetrics;
         }
         private SessionStorage _sessionStorage = new SessionStorage();
    
@@ -105,6 +108,7 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
                 _duration = _sessionStorage._duration;
                 
                 Resume();
+                _sessionStorage = null;
             }
             else
             {
@@ -213,6 +217,21 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
             MobileAnalyticsManager.GetInstance(_appid).RecordEvent(customEvent);
         }
         
+        private void AddStoredGlobalAttributesAndMetricsToEvent(CustomEvent customEvent) {
+            if (_sessionStorage != null) {
+                if (_sessionStorage._globalAttributes != null) {
+                    foreach (var globalAttributePair in _sessionStorage._globalAttributes) {
+                        customEvent.AddAttribute(globalAttributePair.Key, globalAttributePair.Value);
+                    }
+                }
+                if (_sessionStorage._globalMetrics != null) {
+                    foreach (var globalMetricPair in _sessionStorage._globalMetrics) {
+                        customEvent.AddMetric(globalMetricPair.Key, globalMetricPair.Value);
+                    }
+                }
+            }
+        }
+
         private void StopSession()
         {
             DateTime currentTime = DateTime.UtcNow;
@@ -226,6 +245,7 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
                 
                 managerEvent.Duration = _duration;
             }
+            AddStoredGlobalAttributesAndMetricsToEvent(managerEvent);
             MobileAnalyticsManager.GetInstance(_appid).RecordEvent(managerEvent);
         }
         
@@ -264,6 +284,7 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
                     
                 customEvent.Duration = _duration;
             }
+            AddStoredGlobalAttributesAndMetricsToEvent(customEvent);
             MobileAnalyticsManager.GetInstance(_appid).RecordEvent(customEvent);
         }
         
@@ -277,6 +298,8 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
                 _sessionStorage._preStartTime = _preStartTime;
                 _sessionStorage._sessionId = _sessionId;
                 _sessionStorage._duration = _duration;
+                _sessionStorage._globalAttributes = CustomEvent.GetGlobalAttributes();
+                _sessionStorage._globalMetrics = CustomEvent.GetGlobalMetrics();
             }
 
             // store session into file

--- a/Assets/AWSSDK/src/Services/MobileAnalytics/Custom/Session/_unity/Session.unity.cs
+++ b/Assets/AWSSDK/src/Services/MobileAnalytics/Custom/Session/_unity/Session.unity.cs
@@ -108,7 +108,6 @@ namespace Amazon.MobileAnalytics.MobileAnalyticsManager.Internal
                 _duration = _sessionStorage._duration;
                 
                 Resume();
-                _sessionStorage = null;
             }
             else
             {


### PR DESCRIPTION
https://github.com/aws/aws-sdk-unity/issues/99

Storing global metrics and attributes in SessionStorage object to send them with the post-launch Stop / Resume session events